### PR TITLE
Agregamos links a Wayback Machine - parte 2

### DIFF
--- a/programador/pruebas-son-rigor-ingenieril.md
+++ b/programador/pruebas-son-rigor-ingenieril.md
@@ -4,7 +4,7 @@ title: Las pruebas son el rigor ingenieril del desarrollo de software
 overview: true
 author: Neal Ford
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Testing_Is_the_Engineering_Rigor_of_Software_Development
+original: https://web.archive.org/web/20150114192438/http://programmer.97things.oreilly.com/wiki/index.php/Testing_Is_the_Engineering_Rigor_of_Software_Development
 ---
 
 Los desarrolladores aman usar metáforas torturadoras cuando se trata de

--- a/programador/registros-detallados-quitaran-sueno.md
+++ b/programador/registros-detallados-quitaran-sueno.md
@@ -4,7 +4,7 @@ title: Los registros detallados perturbarán tu sueño
 overview: true
 author: Johannes Brodwall
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Verbose_Logging_Will_Disturb_Your_Sleep
+original: https://web.archive.org/web/20150118225438/http://programmer.97things.oreilly.com/wiki/index.php/Verbose_Logging_Will_Disturb_Your_Sleep
 ---
 
 Cuando me encuentro un sistema que ya ha estado en desarrollo o

--- a/programador/regla-boy-scout.md
+++ b/programador/regla-boy-scout.md
@@ -4,7 +4,7 @@ title: La Regla Boy Scout
 overview: true
 author: Uncle Bob
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule
+original: https://web.archive.org/web/20150201232513/http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule
 ---
 
 Los Boy Scout tienen una regla: “Siempre deja el lugar de acampamento

--- a/programador/regla-oro-api.md
+++ b/programador/regla-oro-api.md
@@ -4,7 +4,7 @@ title: La regla de oro del diseño de API
 overview: true
 author: Michael Feathers
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/The_Golden_Rule_of_API_Design
+original: https://web.archive.org/web/20150114192443/http://programmer.97things.oreilly.com/wiki/index.php/The_Golden_Rule_of_API_Design
 ---
 
 El diseño de API es difícil, particularmente los grandes. Si estás

--- a/programador/reinventa-rueda-frecuentemente.md
+++ b/programador/reinventa-rueda-frecuentemente.md
@@ -4,7 +4,7 @@ title: Reinventa la rueda frecuentemente
 overview: true
 author: Jason P Sage
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Reinvent_the_Wheel_Often
+original: https://web.archive.org/web/20150114192331/http://programmer.97things.oreilly.com/wiki/index.php/Reinvent_the_Wheel_Often
 ---
 
 > “Sólo tienes que utilizar algo existente, es una tontería reinventar


### PR DESCRIPTION
Con estos no hubo de enero 2015 para el artículo de **la regla boy scout**, así que puse el más cercano, el 1 de febrero de 2015. De nuevo, estos atacan el #23 

Van los siguientes 5:
- programador/pruebas-son-rigor-ingenieril.md
- programador/registros-detallados-quitaran-sueno.md
- programador/regla-boy-scout.md
- programador/regla-oro-api.md
- programador/reinventa-rueda-frecuentemente.md