### PR TITLE
Agregamos links a Wayback Machine - parte 3 (ya de una vez todos)

### DIFF
--- a/programador/resiste-tentacion-singleton.md
+++ b/programador/resiste-tentacion-singleton.md
@@ -4,7 +4,7 @@ title: Resiste la tentación del patrón Singleton
 overview: true
 author: Sam Saariste
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Resist_the_Temptation_of_the_Singleton_Pattern
+original: https://web.archive.org/web/20150116014108/http://programmer.97things.oreilly.com/wiki/index.php/Resist_the_Temptation_of_the_Singleton_Pattern
 ---
 
 El patrón [Singleton][1] resuelve muchos de tus problemas. Sabes que

--- a/programador/retrocede-automatiza.md
+++ b/programador/retrocede-automatiza.md
@@ -4,7 +4,7 @@ title: Retrocede y Automatiza, Automatiza, Automatiza
 overview: true
 author: Cay Horstmann
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Step_Back_and_Automate%2C_Automate%2C_Automate
+original: https://web.archive.org/web/20150114192418/http://programmer.97things.oreilly.com/wiki/index.php/Step_Back_and_Automate%2C_Automate%2C_Automate
 ---
 
 
@@ -68,4 +68,3 @@ automatizada, aprende sólo lo necesario acerca de la herramienta para
 hacerlo. Hazlo al inicio del proyecto cuando el tiempo es más fácil de
 encontrar. Una vez que has tenido éxito, tú y tu jefe verán que tiene
 sentido invertir en automatización.
-

--- a/programador/revisa-tu-codigo.md
+++ b/programador/revisa-tu-codigo.md
@@ -4,7 +4,7 @@ title: Primero revisa tu código antes de buscar culpar a otros
 overview: true
 author: Allan Kelly
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Check_Your_Code_First_before_Looking_to_Blame_Others
+original: https://web.archive.org/web/20150114190835/http://programmer.97things.oreilly.com/wiki/index.php/Check_Your_Code_First_before_Looking_to_Blame_Others
 ---
 
 Los desarrolladores –¡todos nosotros!– frecuentemente tenemos problemas

--- a/programador/revisiones-codigo.md
+++ b/programador/revisiones-codigo.md
@@ -4,7 +4,7 @@ title: Revisiones de código
 overview: true
 author: Mattias Karlsson
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Code_Reviews
+original: https://web.archive.org/web/20150109162125/http://programmer.97things.oreilly.com/wiki/index.php/Code_Reviews
 ---
 
 Deberías hacer revisiones de código. ¿Por qué? Porque incrementan la
@@ -63,4 +63,3 @@ difícil motivar a cualquiera. Que sea una revisión de código informal,
 cuyo propósito principal sea compartir conocimiento entre los miembros
 del equipo. Deja los comentarios sarcásticos fuera y trae un pastel o
 almuerzo en bolsa café en su lugar.
-

--- a/programador/simplicidad-reduccion.md
+++ b/programador/simplicidad-reduccion.md
@@ -4,7 +4,7 @@ title: La Simplicidad viene de la Reducción
 overview: true
 author: Paul W. Homer
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Simplicity_Comes_from_Reduction
+original: https://web.archive.org/web/20150114192358/http://programmer.97things.oreilly.com/wiki/index.php/Simplicity_Comes_from_Reduction
 ---
 
 “Hazlo de nuevo…”, me dijo el jefe mientras su dedo presionaba con
@@ -55,4 +55,3 @@ importantes.
 Por supuesto, si no lo logra, entonces sólo borra todo y escríbelo una
 vez más. Iniciar el diseño desde lo recordado a menudo puede ayudar a
 cortar una gran cantidad de desorden innecesario.
-

--- a/programador/solo-codigo-dice-verdad.md
+++ b/programador/solo-codigo-dice-verdad.md
@@ -4,7 +4,7 @@ title: Sólo el código dice la verdad
 overview: true
 author: Peter Sommerlad
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Only_the_Code_Tells_the_Truth
+original: https://web.archive.org/web/20150114191237/http://programmer.97things.oreilly.com/wiki/index.php/Only_the_Code_Tells_the_Truth
 ---
 
 La semántica final de un programa está dada por el código que se
@@ -59,4 +59,3 @@ agradecerán. Y, si eres un programador de mantenimiento y el código en
 el que estás trabajando no dice la verdad fácilmente, aplica las
 directrices anteriores de manera proactiva. Establece algo de cordura en
 el código y mantén tu propia cordura.
-

--- a/programador/suelta-raton-alejate-teclado.md
+++ b/programador/suelta-raton-alejate-teclado.md
@@ -4,7 +4,7 @@ title: Suelta el ratón y aléjate del teclado
 overview: true
 author: Cay Horstmann
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Put_the_Mouse_Down_and_Step_Away_from_the_Keyboard
+original: https://web.archive.org/web/20150302171121/http://programmer.97things.oreilly.com/wiki/index.php/Put_the_Mouse_Down_and_Step_Away_from_the_Keyboard
 ---
 
 Te has enfocado por horas en algún raro problema y no hay solución a la
@@ -84,4 +84,3 @@ involucre el lado creativo de tu cerebro; esboza el problema, escucha
 algo de música o da un paseo al aire libre. A veces la mejor cosa que
 puedes hacer para resolver un problema es soltar el ratón y alejarte del
 teclado.
-

--- a/programador/testers-amigos.md
+++ b/programador/testers-amigos.md
@@ -4,7 +4,7 @@ title: Noticias raras - Los testers son tus amigos
 overview: true
 author: Burk Hufnagel
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/News_of_the_Weird:_Testers_Are_Your_Friends
+original: https://web.archive.org/web/20150114191220/http://programmer.97things.oreilly.com/wiki/index.php/News_of_the_Weird:_Testers_Are_Your_Friends
 ---
 
 Ya sea que se llamen ellos mismos Aseguramiento de Calidad (QC, _Quality
@@ -63,4 +63,3 @@ programadores.
 Así que por extraño que suene, estos _testers_, quienes parecen
 determinados a exponer cada pequeño error en tu código, son realmente
 tus amigos.
-

--- a/programador/toma-ventaja-analisis-codigo.md
+++ b/programador/toma-ventaja-analisis-codigo.md
@@ -4,7 +4,7 @@ title: Toma ventaja de las herramientas de análisis de código
 overview: true
 author: Sarah Mount
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Take_Advantage_of_Code_Analysis_Tools
+original: https://web.archive.org/web/20150114192428/http://programmer.97things.oreilly.com/wiki/index.php/Take_Advantage_of_Code_Analysis_Tools
 ---
 
 El valor de las pruebas es algo que está siendo inculcado a los
@@ -65,4 +65,3 @@ excepción no capturada.
 Así que no dejes que las pruebas sean el final de tu aseguramiento de
 calidad; toma ventaja de las herramientas de análisis y no tengas miedo
 de complicarte.
-

--- a/programador/tus-clientes.md
+++ b/programador/tus-clientes.md
@@ -4,7 +4,7 @@ title: Tus clientes no quieren decir lo que dicen
 overview: true
 author: Nate Jackson
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Your_Customers_Do_not_Mean_What_They_Say
+original: https://web.archive.org/web/20150114192906/http://programmer.97things.oreilly.com/wiki/index.php/Your_Customers_Do_not_Mean_What_They_Say
 ---
 
 Nunca he conocido a un cliente que no estuviera muy feliz de decirme qué
@@ -63,4 +63,3 @@ día en que mostramos al cliente el fruto de nuestra labor. Al ver el
 producto, las palabras exactas sobre el color de fondo fueron:
 “Cuando dije negro, me refería a blanco”. Así que, ya ves, nunca es
 tan claro como el blanco y negro.
-

--- a/programador/un-binario.md
+++ b/programador/un-binario.md
@@ -4,7 +4,7 @@ title: Un binario
 overview: true
 author: Steve Freeman
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/One_Binary
+original: https://web.archive.org/web/20150507121807/http://programmer.97things.oreilly.com/wiki/index.php/One_Binary
 ---
 
 He visto muchos proyectos en los cuales la compilación reescribe alguna

--- a/programador/usa-algoritmo-estructura-de-datos-correcto.md
+++ b/programador/usa-algoritmo-estructura-de-datos-correcto.md
@@ -4,7 +4,7 @@ title: Usa el algoritmo y estructura de datos correctos
 overview: true
 author: JC van Winkel
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/Use_the_Right_Algorithm_and_Data_Structure
+original: https://web.archive.org/web/20150101015029/http://programmer.97things.oreilly.com/wiki/index.php/Use_the_Right_Algorithm_and_Data_Structure
 ---
 
 Un gran banco con muchas sucursales se quejó de que las nuevas
@@ -87,4 +87,3 @@ Entonces, lee algunos buenos libros y asegúrate de que los entiendas. Si
 realmente lees bien El arte de la programación, de Donald Knuth, podrías
 incluso ser afortunado: encuentra una equivocación del autor y gana uno
 de los cheques de dólares hexadecimales ($2.56).
-

--- a/programador/wet-dispersa-cuellos-de-botella.md
+++ b/programador/wet-dispersa-cuellos-de-botella.md
@@ -4,7 +4,7 @@ title: El WET dispersa los cuellos de botella en el rendimiento
 overview: true
 author: Kirk Pepperdine
 translator: Espartaco Palma
-original: http://programmer.97things.oreilly.com/wiki/index.php/WET_Dilutes_Performance_Bottlenecks
+original: https://web.archive.org/web/20150110063514/http://programmer.97things.oreilly.com/wiki/index.php/WET_Dilutes_Performance_Bottlenecks
 ---
 
 La importancia del principio DRY ([No te repitas][1]) es que codifica la


### PR DESCRIPTION
Perdón, me dio hueva seguir haciéndolo de 5 en 5. Aquí van todos los demás que faltan. Estos terminan la lista en el #23 . Cabe resaltar que en `programador/suelta-raton-alejate-teclado.md` no hubo de enero 2015, así que puse de marzo y en `programador/un-binario.md` tampoco hubo y puse de mayo.

- programador/resiste-tentacion-singleton.md
- programador/retrocede-automatiza.md
- programador/revisa-tu-codigo.md
- programador/revisiones-codigo.md
- programador/simplicidad-reduccion.md
- programador/solo-codigo-dice-verdad.md
- programador/suelta-raton-alejate-teclado.md
- programador/testers-amigos.md
- programador/toma-ventaja-analisis-codigo.md
- programador/tus-clientes.md
- programador/un-binario.md
- programador/usa-algoritmo-estructura-de-datos-correcto.md
- programador/wet-dispersa-cuellos-de-botella.md